### PR TITLE
Add a @BQConfigProperty for 'compactPath' in ContextHandler

### DIFF
--- a/bootique-jetty-docs/src/docbkx/bootique-jetty-docs/configuration.xml
+++ b/bootique-jetty-docs/src/docbkx/bootique-jetty-docs/configuration.xml
@@ -122,6 +122,11 @@
                                 >Jetty default servlet docs</link>.</para>
                     </td>
                 </tr>
+                <tr>
+                    <td><code>compactPath</code></td>
+                    <td><code>false</code></td>
+                    <td>True if URLs are compacted to replace multiple '/'s with a single '/'</td>
+                </tr>
         </tbody>
     </table>
     </section>

--- a/bootique-jetty/src/main/java/io/bootique/jetty/server/ServerFactory.java
+++ b/bootique-jetty/src/main/java/io/bootique/jetty/server/ServerFactory.java
@@ -68,7 +68,6 @@ public class ServerFactory {
         this.idleThreadTimeout = 60000;
         this.sessions = true;
         this.compression = true;
-        this.compactPath = false;
     }
 
     public Server createServer(Set<MappedServlet> servlets, Set<MappedFilter> filters, Set<MappedListener> listeners) {

--- a/bootique-jetty/src/main/java/io/bootique/jetty/server/ServerFactory.java
+++ b/bootique-jetty/src/main/java/io/bootique/jetty/server/ServerFactory.java
@@ -50,6 +50,7 @@ public class ServerFactory {
     private Map<String, String> params;
     private FolderResourceFactory staticResourceBase;
     private boolean compression;
+    private boolean compactPath;
     // defined as "int" in Jetty, so we should not exceed max int
     private int maxFormContentSize;
     private int maxFormKeys;
@@ -67,6 +68,7 @@ public class ServerFactory {
         this.idleThreadTimeout = 60000;
         this.sessions = true;
         this.compression = true;
+        this.compactPath = false;
     }
 
     public Server createServer(Set<MappedServlet> servlets, Set<MappedFilter> filters, Set<MappedListener> listeners) {
@@ -117,6 +119,7 @@ public class ServerFactory {
 
         ServletContextHandler handler = new ServletContextHandler(options);
         handler.setContextPath(context);
+        handler.setCompactPath(compactPath);
         if (params != null) {
             params.forEach((k, v) -> handler.setInitParameter(k, v));
         }
@@ -432,6 +435,15 @@ public class ServerFactory {
     public void setCompression(boolean compression) {
         this.compression = compression;
     }
+
+    /**
+     * Compact URLs with multiple '/'s with a single '/'.
+     *
+     * @param compactPath Compact URLs with multiple '/'s with a single '/'. Default value is 'false'
+     * @since 0.26
+     */
+    @BQConfigProperty("Replaces multiple '/'s with a single '/' in URL. Default value is 'false'.")
+    public void setCompactPath(boolean compactPath) { this.compactPath = compactPath; }
 
     /**
      * Sets the maximum size of submitted forms in bytes. Default is 200000 (~195K).

--- a/bootique-jetty/src/test/java/io/bootique/jetty/JettyModuleProvider_MetadataIT.java
+++ b/bootique-jetty/src/test/java/io/bootique/jetty/JettyModuleProvider_MetadataIT.java
@@ -78,6 +78,7 @@ public class JettyModuleProvider_MetadataIT {
         });
 
         assertEquals("jetty" +
+                "[compactPath:boolean]" +
                 "[compression:boolean]" +
                 "[list:connectors<io.bootique.jetty.connector.ConnectorFactory>]" +
                 "[context:java.lang.String]" +


### PR DESCRIPTION
Jetty server has a possibility to compact URL's by ContextHandler.setCompactPath. We need to use this feature, but it can be configured by JMX only (ContextHandler is mbean), bootique does not support flag changing.
ContextHandler instance creates by ServerFactory, factory manages by several BQConfigProperties. I propose to add new @BQConfigProperty 'compactPath' in ServerFactory.