### PR TITLE
added docs for using Gradle

### DIFF
--- a/bootique-jetty-docs/src/main/asciidoc/_chapters/_01_jetty_integration.adoc
+++ b/bootique-jetty-docs/src/main/asciidoc/_chapters/_01_jetty_integration.adoc
@@ -26,6 +26,9 @@ Jetty (e.g. set connector ports) and your apps (e.g. map servlet URL patterns an
 `bootique-jetty` is "drag-and-drop" just like any other Bootique module. It is enabled by simply adding it to the
 `pom.xml` dependencies (assuming `autoLoadModules()` is in effect):
 
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -33,6 +36,18 @@ Jetty (e.g. set connector ports) and your apps (e.g. map servlet URL patterns an
     <artifactId>bootique-jetty</artifactId>
 </dependency>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+{
+  implementation: 'io.bootique.jetty:bootique-jetty'
+}
+----
+====
 
 Alternatively you may include an <<merics-and-healthchecks,"instrumented" version>> of `bootique-jetty` that will
 enable a number of metrics for your running app. Either the regular or the instrumented Jetty modules provide `--server`

--- a/bootique-jetty-docs/src/main/asciidoc/_chapters/_03_extension_modules.adoc
+++ b/bootique-jetty-docs/src/main/asciidoc/_chapters/_03_extension_modules.adoc
@@ -26,6 +26,10 @@ extensions.
 
 You may use an "instrumented" version `bootique-jetty`, that will extend the server with a number of metrics
 and health checks for your running app:
+
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -33,11 +37,25 @@ and health checks for your running app:
     <artifactId>bootique-jetty-instrumented</artifactId>
 </dependency>
 ----
+====
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+{
+  implementation: 'io.bootique.jetty:bootique-jetty-instrumented'
+}
+----
+====
 
 === Support for CORS
 If the services running on Jetty are accessed from other domains, you may need to explicitly configure CORS rules to
 to prevent the browsers from blocking access. To achieve that include the following module:
 
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -45,6 +63,17 @@ to prevent the browsers from blocking access. To achieve that include the follow
     <artifactId>bootique-jetty-cors</artifactId>
 </dependency>
 ----
+====
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+{
+  implementation: 'io.bootique.jetty:bootique-jetty-cors'
+}
+----
+====
 
 and then configure rules in YAML under "jettycors" root element (see details <<jettycors, here>>).
 
@@ -52,6 +81,9 @@ and then configure rules in YAML under "jettycors" root element (see details <<j
 If in addition to HTTP requests, you'd like your server to provide access via websockets, you need to add the following
 module:
 
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -59,6 +91,18 @@ module:
     <artifactId>bootique-jetty-websocket</artifactId>
 </dependency>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+{
+  implementation: 'io.bootique.jetty:bootique-jetty-websocket'
+}
+----
+====
 
 Somewhat similar to servlets, the application will need to provide its own classes for websocket endpoints (that must
 follow JSR-356 API to be recognized as endpoonts). Then you need to register them using `JettyWebSocketModule` extender:

--- a/bootique-jetty-docs/src/main/asciidoc/_chapters/_04_testing.adoc
+++ b/bootique-jetty-docs/src/main/asciidoc/_chapters/_04_testing.adoc
@@ -23,6 +23,10 @@ generic Bootique test tools (`BQTestFactory`), however this would require a bit 
 all the cool features like dynamic ports and response assertions.
 
 To use "bootique-jetty" test extensions, import the following module in the "test" scope:
+
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -31,6 +35,19 @@ To use "bootique-jetty" test extensions, import the following module in the "tes
     <scope>test</scope>
 </dependency>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+{
+  testImplementation: 'io.bootique.jetty:bootique-jetty-junit5:test'
+}
+----
+====
+
 Most Jetty tests start like this:
 [source,java,indent=0]
 ----


### PR DESCRIPTION
Sample Maven and Gradle dependencies are provided as dropdown text. 
Maven dependencies are open by default.